### PR TITLE
Fix #103 via @liyufan

### DIFF
--- a/icrawler/crawler.py
+++ b/icrawler/crawler.py
@@ -134,6 +134,7 @@ class Crawler:
         """
         if headers is None:
             headers = {
+                'Accept-Language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
                 "User-Agent": (
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
                     " AppleWebKit/537.36 (KHTML, like Gecko) "


### PR DESCRIPTION
@liyufan posted a fix for "KeyError:'data' when using BaiduImageCrawler" when the response is:

`{"antiFlag":1,"message":"Forbid spider access","bfe_log_id":"xxxxxx random numbers xxxxxx"}`

Other errors should log the JSON received but I did not include that.

`if content["data"]
	...
else
	self.logger.debug(content)`

Log default headers in pownloader.py 116:

'        while retry > 0 and not self.signal.get("reach_max_num"):
            try:
                response = self.session.get(file_url, timeout=timeout)
                #POF TEMP:
                self.logger.error(response.request.headers)'